### PR TITLE
Remove lib dir because gradle-embulk-plugins generates when building

### DIFF
--- a/lib/embulk/input/spanner.rb
+++ b/lib/embulk/input/spanner.rb
@@ -1,3 +1,0 @@
-Embulk::JavaPlugin.register_input(
-  "spanner", "org.embulk.input.spanner.SpannerInputPlugin",
-  File.expand_path('../../../../classpath', __FILE__))


### PR DESCRIPTION
Follow up #1 
