### PR TITLE
Ship v0.0.2

### DIFF
--- a/CHENGELOG.md
+++ b/CHENGELOG.md
@@ -1,3 +1,9 @@
+0.0.2 (2021-11-05)
+==================
+
+* [#8](https://github.com/trocco-io/embulk-input-spanner/pull/8) Introduce a subproject `google-cloud-spanner-jdbc-shadow` to avoid guava incompatibility from Embulk's one.
+* [#9](https://github.com/trocco-io/embulk-input-spanner/pull/9) Add `credentials`, `oauth_token`, `optimizer_version` options. Make `json_keyfile` option deprecated.
+
 0.0.1 (2021-10-30)
 ==================
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = 'embulk-input-spanner'
 
-include 'google-cloud-spanner-jdbc-shadow'
+include ':google-cloud-spanner-jdbc-shadow'


### PR DESCRIPTION
* [#8](https://github.com/trocco-io/embulk-input-spanner/pull/8) Introduce a subproject `google-cloud-spanner-jdbc-shadow` to avoid guava incompatibility from Embulk's one.
* [#9](https://github.com/trocco-io/embulk-input-spanner/pull/9) Add `credentials`, `oauth_token`, `optimizer_version` options. Make `json_keyfile` option deprecated.