### PR TITLE
Support to run with Spanner Emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ An embulk input plugin to load records from [Cloud Spanner](https://cloud.google
     ```
 - **oauth_token**: A valid pre-existing OAuth token to use for authentication for this connection. Setting this property will take precedence over any value set for **credentials**. (string, optional)
 - **optimizer_version**: Sets the default query optimizer version to use for this connection. See also https://cloud.google.com/spanner/docs/query-optimizer/query-optimizer-versions. (string, optional)
+- **use_emulator**: Whether to use [the Cloud Spanner emulator](https://github.com/GoogleCloudPlatform/cloud-spanner-emulator). (boolean, default: `false`)
+  - If this option is `true`, the following changes are applied.
+    - `autoConfigEmulator=true` and `usePlainText=true` are set to JDBC connection properties.
+    - Change the way to get the schema of query that executes the query with `max_rows=1` and `fetch_rows=1` properties instead of explaining the query because Spanner Emulator does not support the `PLAN` query mode.
 - **fetch_rows**: number of rows to fetch one time (used for `java.sql.Statement#setFetchSize`) (integer, default: `10000`)
 - **connect_timeout**: not supported.
 - **socket_timeout**: timeout for executing the query. 0 means no timeout. (integer (seconds), default: 1800)

--- a/example/config.yml
+++ b/example/config.yml
@@ -1,12 +1,13 @@
 in:
   type: spanner
-  auth_method: json_key
-  json_key: /path/to/credentials.json
   project_id: test-project
   instance_id: test-instance
   database_id: test-database
-  table: test_table
+  table: Singers
+  use_emulator: true
   socket_timeout: 0
+  column_options:
+    SingerInfo: {value_type: string}
 
 out:
   type: stdout

--- a/src/main/java/org/embulk/input/spanner/SpannerInputPlugin.java
+++ b/src/main/java/org/embulk/input/spanner/SpannerInputPlugin.java
@@ -59,6 +59,10 @@ public class SpannerInputPlugin extends AbstractJdbcInputPlugin {
     @Config("optimizer_version")
     @ConfigDefault("null")
     public Optional<String> getOptimizerVersion();
+
+    @Config("use_emulator")
+    @ConfigDefault("false")
+    public boolean getUseEmulator();
   }
 
   @Override
@@ -123,6 +127,10 @@ public class SpannerInputPlugin extends AbstractJdbcInputPlugin {
             file -> props.setProperty("credentials", file.getPath().toAbsolutePath().toString()));
     task.getOauthToken().ifPresent(token -> props.setProperty("oauthToken", token));
     task.getOptimizerVersion().ifPresent(version -> props.setProperty("optimizerVersion", version));
+    if (task.getUseEmulator()) {
+      props.setProperty("autoConfigEmulator", "true");
+      props.setProperty("usePlainText", "true");
+    }
     props.putAll(task.getOptions());
     return props;
   }

--- a/src/main/java/org/embulk/input/spanner/SpannerInputPlugin.java
+++ b/src/main/java/org/embulk/input/spanner/SpannerInputPlugin.java
@@ -85,7 +85,7 @@ public class SpannerInputPlugin extends AbstractJdbcInputPlugin {
     Connection con =
         DriverManager.getConnection(buildJdbcConnectionUrl(t), buildJdbcConnectionProperties(t));
     try {
-      SpannerJdbcInputConnection c = new SpannerJdbcInputConnection(con);
+      SpannerJdbcInputConnection c = new SpannerJdbcInputConnection(con, t.getUseEmulator());
       con = null;
       return c;
     } finally {

--- a/src/main/java/org/embulk/input/spanner/jdbc/SpannerJdbcInputConnection.java
+++ b/src/main/java/org/embulk/input/spanner/jdbc/SpannerJdbcInputConnection.java
@@ -1,11 +1,40 @@
 package org.embulk.input.spanner.jdbc;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import org.embulk.input.jdbc.JdbcInputConnection;
+import org.embulk.input.jdbc.JdbcSchema;
 
 public class SpannerJdbcInputConnection extends JdbcInputConnection {
+
+  private final boolean useEmulator;
+
   public SpannerJdbcInputConnection(Connection connection) throws SQLException {
+    this(connection, false);
+  }
+
+  public SpannerJdbcInputConnection(Connection connection, boolean useEmulator)
+      throws SQLException {
     super(connection, null);
+    this.useEmulator = useEmulator;
+  }
+
+  @Override
+  public JdbcSchema getSchemaOfQuery(String query) throws SQLException {
+    return useEmulator ? getSchemaOfQueryForSpannerEmulator(query) : super.getSchemaOfQuery(query);
+  }
+
+  protected JdbcSchema getSchemaOfQueryForSpannerEmulator(String query) throws SQLException {
+    try (PreparedStatement stmt = connection.prepareStatement(query)) {
+      // NOTE: We want to set `LIMIT 0` to the query, but it is difficult to do.
+      //       So, setMaxRows(1) and setFetchSize(1) are used instead.
+      stmt.setMaxRows(1);
+      stmt.setFetchSize(1);
+      try (ResultSet rs = stmt.executeQuery()) {
+        return getSchemaOfResultMetadata(rs.getMetaData());
+      }
+    }
   }
 }


### PR DESCRIPTION
* Add `use_emulator` option to set the JDBC parameters: `autoConfigEmulator=true`, `usePlainText=true`.
* Implement `getSchemaOfQueryForSpannerEmulator` method to avoid the error `UNIMPLEMENTED: The emulator does not support the PLAN query mode.`. Internally, instead of using `EXPLAIN`, we actually execute the query to get the schema output by the query.